### PR TITLE
Wait Step

### DIFF
--- a/ResearchKit.xcodeproj/project.pbxproj
+++ b/ResearchKit.xcodeproj/project.pbxproj
@@ -474,7 +474,7 @@
 		CA8D0E931BC4360F00BED0F7 /* ORKWaitStepView.m in Sources */ = {isa = PBXBuildFile; fileRef = CA8D0E911BC4360F00BED0F7 /* ORKWaitStepView.m */; settings = {ASSET_TAGS = (); }; };
 		CB16A6F01BB0D0960043CDD8 /* ORKWaitStep.h in Headers */ = {isa = PBXBuildFile; fileRef = CB16A6EC1BB0D0960043CDD8 /* ORKWaitStep.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CB16A6F11BB0D0960043CDD8 /* ORKWaitStep.m in Sources */ = {isa = PBXBuildFile; fileRef = CB16A6ED1BB0D0960043CDD8 /* ORKWaitStep.m */; settings = {ASSET_TAGS = (); }; };
-		CB16A6F21BB0D0960043CDD8 /* ORKWaitStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = CB16A6EE1BB0D0960043CDD8 /* ORKWaitStepViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB16A6F21BB0D0960043CDD8 /* ORKWaitStepViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = CB16A6EE1BB0D0960043CDD8 /* ORKWaitStepViewController.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CB16A6F31BB0D0960043CDD8 /* ORKWaitStepViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CB16A6EF1BB0D0960043CDD8 /* ORKWaitStepViewController.m */; settings = {ASSET_TAGS = (); }; };
 		D42FEFB81AF7557000A124F8 /* ORKImageCaptureView.h in Headers */ = {isa = PBXBuildFile; fileRef = D42FEFB61AF7557000A124F8 /* ORKImageCaptureView.h */; };
 		D42FEFB91AF7557000A124F8 /* ORKImageCaptureView.m in Sources */ = {isa = PBXBuildFile; fileRef = D42FEFB71AF7557000A124F8 /* ORKImageCaptureView.m */; };
@@ -2116,10 +2116,10 @@
 			children = (
 				CB16A6EC1BB0D0960043CDD8 /* ORKWaitStep.h */,
 				CB16A6ED1BB0D0960043CDD8 /* ORKWaitStep.m */,
-				CA8D0E901BC4360F00BED0F7 /* ORKWaitStepView.h */,
-				CA8D0E911BC4360F00BED0F7 /* ORKWaitStepView.m */,
 				CB16A6EE1BB0D0960043CDD8 /* ORKWaitStepViewController.h */,
 				CB16A6EF1BB0D0960043CDD8 /* ORKWaitStepViewController.m */,
+				CA8D0E901BC4360F00BED0F7 /* ORKWaitStepView.h */,
+				CA8D0E911BC4360F00BED0F7 /* ORKWaitStepView.m */,
 			);
 			name = "Wait Step";
 			path = ../ActiveTasks;

--- a/ResearchKit/Common/ORKDefines.h
+++ b/ResearchKit/Common/ORKDefines.h
@@ -140,11 +140,12 @@ typedef NS_ENUM(NSInteger, ORKPasscodeType) {
 
 
 /**
- Progress Indicator Mask
+ Progress indicator type for `ORKWaitStep`.
  */
-typedef NS_OPTIONS(NSInteger, ORKProgressIndicatorMask) {
+typedef NS_ENUM(NSInteger, ORKProgressIndicatorType) {
     /// Spinner animation.
-    ORKProgressIndicatorMaskIndeterminate = 0,
+    ORKProgressIndicatorTypeIndeterminate = 0,
+    
     /// Progressbar animation.
-    ORKProgressIndicatorMaskProgressBar,
+    ORKProgressIndicatorTypeProgressBar,
 } ORK_ENUM_AVAILABLE;

--- a/ResearchKit/Common/ORKWaitStep.h
+++ b/ResearchKit/Common/ORKWaitStep.h
@@ -57,9 +57,9 @@ ORK_CLASS_AVAILABLE
 /**
  This property specifies the type of progress bar that will be displayed.
  
- ORKProgressIndicatorMaskIndeterminate (default) is for indeterminate duration operations
- ORKProgressIndicatorMaskProgressBar is for determinate duration operations
+ ORKProgressIndicatorTypeIndeterminate (default) is for indeterminate duration operations
+ ORKProgressIndicatorTypeProgressBar is for determinate duration operations
  */
-@property (nonatomic, assign) ORKProgressIndicatorMask indicatorMask;
+@property (nonatomic) ORKProgressIndicatorType indicatorType;
 
 @end

--- a/ResearchKit/Common/ORKWaitStep.m
+++ b/ResearchKit/Common/ORKWaitStep.m
@@ -51,7 +51,7 @@
 - (instancetype)initWithIdentifier:(NSString *)identifier {
     self = [super initWithIdentifier:identifier];
     if (self) {
-        self.indicatorMask = ORKProgressIndicatorMaskIndeterminate;
+        self.indicatorType = ORKProgressIndicatorTypeIndeterminate;
     }
     return self;
 }
@@ -59,27 +59,27 @@
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
     self = [super initWithCoder:aDecoder];
     if (self) {
-        ORK_DECODE_ENUM(aDecoder, indicatorMask);
+        ORK_DECODE_ENUM(aDecoder, indicatorType);
     }
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
     [super encodeWithCoder:aCoder];
-    ORK_ENCODE_ENUM(aCoder, indicatorMask);
-}
-
-- (BOOL)startsFinished {
-    return NO;
+    ORK_ENCODE_ENUM(aCoder, indicatorType);
 }
 
 + (BOOL)supportsSecureCoding {
     return YES;
 }
 
+- (BOOL)allowsBackNavigation {
+    return NO;
+}
+
 - (instancetype)copyWithZone:(NSZone *)zone {
     ORKWaitStep *step = [super copyWithZone:zone];
-    step.indicatorMask = self.indicatorMask;
+    step.indicatorType = self.indicatorType;
     return step;
 }
 
@@ -88,7 +88,7 @@
     
     __typeof(self) castObject = object;
     return (isParentSame &&
-            self.indicatorMask == castObject.indicatorMask);
+            self.indicatorType == castObject.indicatorType);
 }
 
 @end

--- a/ResearchKit/Common/ORKWaitStepView.h
+++ b/ResearchKit/Common/ORKWaitStepView.h
@@ -6,17 +6,14 @@
 //  Copyright © 2015 researchkit.org. All rights reserved.
 //
 
+
 #import "ORKVerticalContainerView.h"
-#import "ORKProgressView.h"
-#import "ORKDefines.h"
+
 
 @interface ORKWaitStepView : ORKVerticalContainerView
 
-- (instancetype)initWithIndicatorMask:(ORKProgressIndicatorMask)mask heading:(NSString *)heading;
+- (instancetype)initWithIndicatorType:(ORKProgressIndicatorType)type;
 
-@property (nonatomic, strong) ORKSubheadlineLabel *textLabel;
-@property (nonatomic, strong) UIProgressView *progressView;
-@property (nonatomic, strong) ORKProgressView *activityIndicatorView;
-@property (nonatomic, assign) ORKProgressIndicatorMask indicatorMask;
+@property (nonatomic, readonly) UIProgressView *progressView;
 
 @end

--- a/ResearchKit/Common/ORKWaitStepViewController.h
+++ b/ResearchKit/Common/ORKWaitStepViewController.h
@@ -53,13 +53,6 @@ ORK_CLASS_AVAILABLE
 @interface ORKWaitStepViewController: ORKStepViewController
 
 /**
- Sets the progress indicator mask that is currently displayed in the view controller.
- 
- @param mask    The mask to display in the wait step view controller.
- */
-- (void)setCurrentProgressIndicatorMask:(ORKProgressIndicatorMask)mask;
-
-/**
  Updates the amount of progress displayed in the progress bar if the current indicator mask is set to progress bar.
  
  @param progress    The fraction of work completed on the range of zero to one.
@@ -68,10 +61,10 @@ ORK_CLASS_AVAILABLE
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 
 /**
- Updates the description of the process that is occuring.
+ Updates the text on the step with the process that is occuring.
  
- @param description     The description of the process that is occuring.
-*/
-- (void)setProgressDescription:(NSString *)description;
+ @param text     The description of the process that is occuring.
+ */
+- (void)updateText:(NSString *)text;
 
 @end

--- a/ResearchKit/Common/ORKWaitStepViewController.m
+++ b/ResearchKit/Common/ORKWaitStepViewController.m
@@ -40,77 +40,60 @@
 #import "ORKWaitStepViewController.h"
 #import "ORKStepViewController_Internal.h"
 #import "ORKWaitStepView.h"
-
-
-@interface ORKWaitStepViewController ()
-
-@property (nonatomic, strong) ORKWaitStepView *waitStepView;
-
-@end
+#import "ORKHelpers.h"
 
 
 @implementation ORKWaitStepViewController {
-    ORKProgressIndicatorMask _indicatorMask;
+    ORKWaitStepView *_waitStepView;
+    ORKProgressIndicatorType _indicatorType;
 }
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    
-    self.learnMoreButtonItem = nil;
-    [self stepDidChange];
+- (ORKWaitStep *)waitStep {
+    return (ORKWaitStep *)self.step;
 }
 
 - (void)stepDidChange {
     [super stepDidChange];
     
-    if ([self step] && [self isViewLoaded]) {
-        if (!_waitStepView) {
-            _waitStepView = [[ORKWaitStepView alloc] initWithIndicatorMask:((ORKWaitStep *)self.step).indicatorMask
-                                                                   heading:(self.step.title ? self.step.title : ORKLocalizedString(@"WAIT_LABEL", nil))];
-            _waitStepView.translatesAutoresizingMaskIntoConstraints = NO;
-            [self.view addSubview:_waitStepView];
-            [self setUpConstraints];
-        } else {
-            _waitStepView.indicatorMask = ((ORKWaitStep *)self.step).indicatorMask;
-            _waitStepView.textLabel.text = self.step.title ? self.step.title : ORKLocalizedString(@"WAIT_LABEL", nil);
-            [self.view setNeedsUpdateConstraints];
-        }
+    if (self.step && [self isViewLoaded]) {
+        _waitStepView = [[ORKWaitStepView alloc] initWithIndicatorType:[self waitStep].indicatorType];
+        _waitStepView.headerView.captionLabel.text = [self waitStep].title;
+        _waitStepView.headerView.instructionLabel.text = [self waitStep].text;
+
+        [self.view addSubview:_waitStepView];
+        
+        [self setUpConstraints];
     }
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self stepDidChange];
 }
 
 - (void)setUpConstraints {
     NSMutableArray *constraints = [NSMutableArray new];
     
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:_waitStepView
-                                                        attribute:NSLayoutAttributeCenterX
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeCenterX
-                                                       multiplier:1.0
-                                                         constant:0.0]];
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:_waitStepView
-                                                        attribute:NSLayoutAttributeBottom
-                                                        relatedBy:NSLayoutRelationEqual
-                                                           toItem:self.view
-                                                        attribute:NSLayoutAttributeCenterY
-                                                       multiplier:1.0
-                                                         constant:0.0]];
+    NSDictionary *views = @{ @"waitStepView": _waitStepView };
+    ORKEnableAutoLayoutForViews(views.allValues);
     
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[waitStepView]|"
+                                                                             options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                             metrics:nil
+                                                                               views:views]];
+    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[waitStepView]|"
+                                                                             options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                             metrics:nil
+                                                                               views:views]];
     [NSLayoutConstraint activateConstraints:constraints];
-}
-
-- (void)setCurrentProgressIndicatorMask:(ORKProgressIndicatorMask)mask {
-    ((ORKWaitStep *)self.step).indicatorMask = mask;
-    [super stepDidChange];
 }
 
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated {
     [_waitStepView.progressView setProgress:progress animated:animated];
 }
 
-- (void)setProgressDescription:(NSString *)description {
-    _waitStepView.textLabel.text = description;
-    [self.view setNeedsLayout];
+- (void)updateText:(NSString *)text {
+    _waitStepView.headerView.instructionLabel.text = text;
 }
 
 @end

--- a/ResearchKit/Localized/en.lproj/Localizable.strings
+++ b/ResearchKit/Localized/en.lproj/Localizable.strings
@@ -198,8 +198,6 @@
 "TOTAL_TAPS_LABEL" = "Total Taps";
 "TAPPING_INSTRUCTION" = "Tap the buttons as quickly as you can using two fingers.";
 
-/* Wait Task. */
-"WAIT_LABEL" = "Please wait";
 
 /* Audio active task. */
 "AUDIO_TASK_TITLE" = "Voice";

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -3240,7 +3240,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
         stepViewController.navigationItem.titleView = [[UISegmentedControl alloc] initWithItems:items];
     }else if ([stepViewController.step.identifier isEqualToString:@"waitTask.step2"]) {
         // Indeterminate step
-        [((ORKWaitStepViewController *)stepViewController) performSelector:@selector(finish) withObject:nil afterDelay:5.0];
+        [((ORKWaitStepViewController *)stepViewController) performSelector:@selector(goForward) withObject:nil afterDelay:5.0];
     } else if ([stepViewController.step.identifier isEqualToString:@"waitTask.step4"]) {
         // Determinate step
         [self updateProgress:0.0 OfWaitTask:((ORKWaitStepViewController *)stepViewController)];
@@ -3452,6 +3452,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     // Interterminate wait step.
     ORKWaitStep *step2 = [[ORKWaitStep alloc] initWithIdentifier:@"waitTask.step2"];
     step2.title = @"Getting Ready";
+    step2.text = @"Please wait while the setup completes.";
     [steps addObject:step2];
     
     ORKInstructionStep *step3 = [[ORKInstructionStep alloc] initWithIdentifier:@"waitTask.step3"];
@@ -3462,7 +3463,8 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     // Determinate wait step.
     ORKWaitStep *step4 = [[ORKWaitStep alloc] initWithIdentifier:@"waitTask.step4"];
     step4.title = @"Syncing Account";
-    step4.indicatorMask = ORKProgressIndicatorMaskProgressBar;
+    step4.text = @"Please wait while the data is uploaded.";
+    step4.indicatorType = ORKProgressIndicatorTypeProgressBar;
     [steps addObject:step4];
     
     ORKCompletionStep *step5 = [[ORKCompletionStep alloc] initWithIdentifier:@"waitTask.step5"];
@@ -3477,13 +3479,18 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
     if (progress <= 1.0) {
         [viewController setProgress:progress animated:true];
         
-        double delayInSeconds = 2.0;
+        double delayInSeconds = 0.1;
         dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
         __weak ORKWaitStepViewController *vc = viewController;
         __weak MainViewController *weakSelf = self;
         dispatch_after(popTime, dispatch_get_main_queue(), ^(void) {
             __typeof__(self) strongSelf = weakSelf;
-            [strongSelf updateProgress:progress + 0.2 OfWaitTask:vc];
+            [strongSelf updateProgress:progress + 0.01 OfWaitTask:vc];
+            
+            if ((float)progress == 0.5) {
+                NSString *newText = @"Please wait while the data is downloaded/";
+                [viewController updateText:newText];
+            }
         });
     } else {
         [viewController goForward];

--- a/Testing/ORKTest/ORKTest/MainViewController.m
+++ b/Testing/ORKTest/ORKTest/MainViewController.m
@@ -276,7 +276,6 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            ],
                        @[ // Active Tasks
                            @"Active Step Task",
-                           @"Wait Task",
                            @"Audio Task",
                            @"Fitness Task",
                            @"GAIT Task",
@@ -288,6 +287,7 @@ static const CGFloat HeaderSideLayoutMargin = 16.0;
                            @"Tone Audiometry Task",
                            @"Tower Of Hanoi Task",
                            @"Two Finger Tapping Task",
+                           @"Wait Task"
                            ],
                        @[ // Passcode
                            @"Authenticate Passcode",
@@ -3488,7 +3488,7 @@ stepViewControllerWillAppear:(ORKStepViewController *)stepViewController {
             [strongSelf updateProgress:progress + 0.01 OfWaitTask:vc];
             
             if ((float)progress == 0.5) {
-                NSString *newText = @"Please wait while the data is downloaded/";
+                NSString *newText = @"Please wait while the data is downloaded.";
                 [viewController updateText:newText];
             }
         });

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListRow.swift
@@ -951,10 +951,14 @@ enum TaskListRow: Int, CustomStringConvertible {
     /// This task presents a wait task.
     private var waitTask: ORKTask {
         let waitStepIndeterminate = ORKWaitStep(identifier: String(Identifier.WaitStepIndeterminate))
-        waitStepIndeterminate.indicatorMask = ORKProgressIndicatorMask.Indeterminate
+        waitStepIndeterminate.title = exampleQuestionText
+        waitStepIndeterminate.text = exampleDescription
+        waitStepIndeterminate.indicatorType = ORKProgressIndicatorType.Indeterminate
         
         let waitStepDeterminate = ORKWaitStep(identifier: String(Identifier.WaitStepDeterminate))
-        waitStepDeterminate.indicatorMask = ORKProgressIndicatorMask.ProgressBar
+        waitStepDeterminate.title = exampleQuestionText
+        waitStepDeterminate.text = exampleDescription
+        waitStepDeterminate.indicatorType = ORKProgressIndicatorType.ProgressBar
         
         return ORKOrderedTask(identifier: String(Identifier.WaitTask), steps: [waitStepIndeterminate, waitStepDeterminate])
     }

--- a/samples/ORKCatalog/ORKCatalog/Tasks/TaskListViewController.swift
+++ b/samples/ORKCatalog/ORKCatalog/Tasks/TaskListViewController.swift
@@ -145,7 +145,7 @@ class TaskListViewController: UITableViewController, ORKTaskViewControllerDelega
                 if let stepViewController = stepViewController as? ORKWaitStepViewController {
                     self.waitStepViewController = stepViewController;
                     self.waitStepProgress = 0.0
-                    self.waitStepUpdateTimer = NSTimer(timeInterval: 1.0, target: self, selector: "updateProgressOfWaitStepViewController", userInfo: nil, repeats: true)
+                    self.waitStepUpdateTimer = NSTimer(timeInterval: 0.1, target: self, selector: "updateProgressOfWaitStepViewController", userInfo: nil, repeats: true)
                     NSRunLoop.mainRunLoop().addTimer(self.waitStepUpdateTimer!, forMode: NSRunLoopCommonModes)
                 }
             })
@@ -163,7 +163,7 @@ class TaskListViewController: UITableViewController, ORKTaskViewControllerDelega
     
     func updateProgressOfWaitStepViewController() {
         if let waitStepViewController = waitStepViewController {
-            waitStepProgress += 0.2
+            waitStepProgress += 0.01
             dispatch_async(dispatch_get_main_queue(), { () -> Void in
                 waitStepViewController.setProgress(self.waitStepProgress, animated: true)
             })
@@ -172,7 +172,6 @@ class TaskListViewController: UITableViewController, ORKTaskViewControllerDelega
             } else {
                 self.waitStepUpdateTimer?.invalidate()
                 waitStepViewController.goForward()
-                self.waitStepViewController?.setProgressDescription("Complete")
                 self.waitStepViewController = nil
             }
         } else {


### PR DESCRIPTION
### Wait Step
- Make ORKWaitStep - public, make ORKWaitStepViewController - private, make ORKWaitStepView - project.
- **ORKDefines.h**
  - Refactor ORKProgressIndicatorMask into ORKProgressIndicatorType and change from NS_OPTIONS to NS_ENUM.
    - Main reason for this is because we don’t want to allow more than one option at a time.
- **Localizable.strings**
  - Remove the localizable string because we don’t want a fallback text. If the user did not specify a title and text on the step, then it should just show the indicator type.
    - A use case could be to just show the activity indicator view without a message.
- **ORKWaitStep.m**
  - Override `allowsBackNavigation` to disable it because we don’t want the user to be able to go back while the background activity is begin run.
  - Add `copyWithZone` and `isEqual`
- **ORKWaitStepView.h**
  - Remove all properties from .h file except progressView, since that is the only one we need to be exposed.
  - Make progressView - readonly in the .h file.
  - Remove the extra imports from .h file.
  - Update legal header
  - Add extra lines around imports.
  - Change init method because we don’t want a heading anymore.
    - The reason we don’t want a heading is because ORKVerticalContainerView already has a headerView which contains a label. That is where the title and text provided from the STEP should be assigned.
- **ORKWaitStepView.m**
  - Add extra lines around imports
  - Create local variables for the ones we removed from .h file.
  - Instead of adding the progress view to self, add it to self.stepView.
    - StepView is a place where additional UI components should go for an ORKVerticalContainerView class.
  - Also set verticalCenteringEnabled = YES.
  - We don’t need to check for progressView and activituiyindicatorview and remove them from superview because we shouldn’t allow the option to change the indicator type once you have specified it.
    - So consequently, we can just add them to the stepView using a switch statement, and not have to worry about removing them.
  - Since we no longer need the textLabel, we can remove it completely from this file.
    - This includes the constraints and the accessibility.
    - Those will be taken care of by ORKVerticalContainerView which includes the headerView for a title and a text.
- **ORKWaitStepViewController.h**
  - We want to remove setCurrentProgressIndicatorMask, since we don’t want to allow that use case.
  - Refactor setProgressDescription to updateText.
    - This is because we are going to be updating the text property on the headerView of ORKVerticalContainerView.
- **ORKWaitStepViewController.m**
  - Create a method to return waitStep (already casted in the method, so you don’t have to do it again and again).
  - Then just create a waitStepView, assign the title and text from the step to its headerView labels.
  - In constraints, just allow waitStepView to cover horizontally and vertically.
- **TaskListRow.swift**
  - Just assign the global `exampleQuestionText` to step’s title property and `exampleDescription` to step’s text property.
- **TaskViewController.swift**
  - Update the timer interval to be 0.1, and increase progress by 0.01 to give it a smoother progress bar look.
    - Currently, it looks a little fidgety.
- **MainViewController.m**
  - Change the selector for the indeterminateStep to be goForward instead of finish.
    - Finish is only used for ORKActiveStep. Since you refactored to ORKStep, the finish is no longer there, which is causing a crash.
  - Assign text and title to each wait step.
  - Update the progress every 0.01 and change the text when progress is half way done.
    - When the progress is done, call goForward instead of finish.
